### PR TITLE
feat: implement DELETE /entries/{id} endpoint

### DIFF
--- a/api/routers/journal_router.py
+++ b/api/routers/journal_router.py
@@ -94,7 +94,12 @@ async def delete_entry(request: Request, entry_id: str, entry_service: EntryServ
     
     Hint: Look at how the update_entry endpoint checks for existence
     """
-    raise HTTPException(status_code=501, detail="Not implemented - complete this endpoint!")
+    result = await entry_service.get_entry(entry_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Entry not found")
+    
+    await entry_service.delete_entry(entry_id)
+    return {"detail": f"Deleted entry {(entry_id)}"}
 
 @router.delete("/entries")
 async def delete_all_entries(request: Request):


### PR DESCRIPTION
## 📝 Description
Implements DELETE /entries/{entry_id} endpoint for retrieving single journal entries.

## ✅ Testing Done
- [x] Tested with valid entry ID via /docs to see if it deleted entry
- [x] Tested with invalid entry ID (returns 404)
- [x] Verified response matches Entry model schema

## 📸 Screenshots
### Valid Entry Response
<img width="1293" height="514" alt="Screenshot From 2025-09-10 00-54-15" src="https://github.com/user-attachments/assets/9f9b2023-d74f-4ceb-9136-760c987b203e" />

### Invalid Entry Response
<img width="1293" height="514" alt="Screenshot From 2025-09-10 00-56-32" src="https://github.com/user-attachments/assets/a600b412-bb63-4d2f-8c27-5315629e0c89" />

