### PR TITLE
feat: add aws cloud cli setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,13 +6,16 @@
   "features": {
 		// TODO: Add one of these cloud CLI tools based on your needs:
         // "ghcr.io/devcontainers/features/azure-cli:1": {},
-        // "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/devcontainers/features/aws-cli:1": {}
         // "ghcr.io/devcontainers/features/gcloud:1": {}
 	},
   
   "service": "devcontainer",
   "workspaceFolder": "/workspaces/",
-  "runServices": ["postgres"]
+  "runServices": ["postgres"],
+  "mounts": [
+    "type=bind,source=/home/fred/.aws,target=/home/vscode/.aws"
+  ]
   
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],


### PR DESCRIPTION
## 📝 Description  
Adds **AWS CLI** setup to the development container to support deployment workflows.  

## ✅ Testing Done  
- [x] Rebuilt the devcontainer and verified AWS CLI is installed.  
- [x] Ran `aws --version` inside the devcontainer to confirm installation.  
- [x] Confirmed no errors occur when the devcontainer starts with AWS CLI enabled.  

## 📸 Screenshots 
<img width="677" height="65" alt="Screenshot From 2025-09-10 17-09-23" src="https://github.com/user-attachments/assets/44799a57-73d6-4539-a6c2-5d5fa5b935bc" />
